### PR TITLE
add: cors-allowed with port 3000

### DIFF
--- a/backend/djangoapp/jobber/settings.py
+++ b/backend/djangoapp/jobber/settings.py
@@ -16,6 +16,12 @@ ALLOWED_HOSTS = [
     if h.strip()
 ]
 
+# Configurações CORS
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:3000",  # URL do frontend
+]
+
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -25,10 +31,12 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'tasks' # Chamando meu app rest da todolist
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/backend/djangoapp/requirements.txt
+++ b/backend/djangoapp/requirements.txt
@@ -1,4 +1,5 @@
 Django>=5.1,<5.2
 djangorestframework>=3.14.0
+django_cors_headers>=4.4.0
 Pillow>=9.0.0
 psycopg2-binary>=2.9.9,<2.10


### PR DESCRIPTION
Adicionando [Django Cors Headers](https://pypi.org/project/django-cors-headers/) para permitir o front-end em development